### PR TITLE
😺 feat: separate out and rename GH workflow jobs

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -11,7 +11,7 @@ on:
       - '.github/ISSUE_TEMPLATE/*'
 
 jobs:
-  run:
+  build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -25,7 +25,9 @@ jobs:
         if [ -f requirements/requirements-dev.txt ]; then pip install -r  requirements/requirements-dev.txt; fi
         if [ -f requirements/requirements-client.txt ]; then pip install -r  requirements/requirements-client.txt; fi
         if [ -f requirements/requirements-server.txt ]; then pip install -r  requirements/requirements-server.txt; fi
+  codecov:
     - name: Generate coverage report
+      needs: build
       run: |
         pytest -m "not (apitest or dasktest)" --cov-report=xml
     - name: Upload coverage to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         if [ -f requirements/requirements-dev.txt ]; then pip install -r  requirements/requirements-dev.txt; fi
         if [ -f requirements/requirements-client.txt ]; then pip install -r  requirements/requirements-client.txt; fi
         if [ -f requirements/requirements-server.txt ]; then pip install -r  requirements/requirements-server.txt; fi
-  lint:
+  flake8:
     - name: Lint with flake8
       needs: build
       run: |
@@ -37,7 +37,7 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-  test:
+  pytest:
     - name: Test with pytest
       needs: build
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,12 +29,16 @@ jobs:
         if [ -f requirements/requirements-dev.txt ]; then pip install -r  requirements/requirements-dev.txt; fi
         if [ -f requirements/requirements-client.txt ]; then pip install -r  requirements/requirements-client.txt; fi
         if [ -f requirements/requirements-server.txt ]; then pip install -r  requirements/requirements-server.txt; fi
+  lint:
     - name: Lint with flake8
+      needs: build
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  test:
     - name: Test with pytest
+      needs: build
       run: |
         pytest -m "not (apitest or dasktest)"


### PR DESCRIPTION
- Separates out build and test / lint jobs in `codecov.yml` and `test.yml`
- Meaningful IDs are given to jobs (i.e. codecov, flake8, and pytest)